### PR TITLE
Proposing Git Clone Protocol as HTTPS

### DIFF
--- a/qemu_mode/build_qemu_support.sh
+++ b/qemu_mode/build_qemu_support.sh
@@ -116,7 +116,7 @@ echo "[+] Building CGC qemu!"
 QEMU_DIR=qemu-cgc-afl
 rm -rf $QEMU_DIR
 echo "[*] Cloning our QEMU repository..."
-git clone --branch base_cgc git@github.com:mechaphish/qemu-cgc.git $QEMU_DIR || exit 1
+git clone --branch base_cgc https://github.com/mechaphish/qemu-cgc.git $QEMU_DIR || exit 1
 echo "[*] Checking out our current afl pre-patched QEMU version..."
 git -C $QEMU_DIR pull || exit 1
 echo "[+] Checked out."


### PR DESCRIPTION
I've found many networks where ssh is not allowed out. However, SSL tends to be allowed everywhere. Thus, I'm proposing changing this (and likely any others I run across) from ssh pull into https pull to make the build more likely to work.
